### PR TITLE
Use correct errorHandler variable

### DIFF
--- a/server.js
+++ b/server.js
@@ -72,7 +72,7 @@ app.use('/api/v1', api);
  * Error Handler.
  */
 if (process.env.NODE_ENV === 'development') {
-  app.use(errorhandler())
+  app.use(errorHandler())
 }
 
 /**


### PR DESCRIPTION
You're instantiating the variable using camel case, but you're using it below as all lowercase, this was throwing an error in my build.